### PR TITLE
Allow multiple time retrieve the list of shared files

### DIFF
--- a/android/src/main/java/com/reactnativereceivesharingintent/ReceiveSharingIntentHelper.java
+++ b/android/src/main/java/com/reactnativereceivesharingintent/ReceiveSharingIntentHelper.java
@@ -28,6 +28,9 @@ public class ReceiveSharingIntentHelper {
 
   @RequiresApi(api = Build.VERSION_CODES.KITKAT)
   public void sendFileNames(Context context, Intent intent, Promise promise){
+    if (intent == null) {
+      promise.reject("error","Null intent.");
+    }
     try {
       String action = intent.getAction();
       String type = intent.getType();
@@ -165,6 +168,7 @@ public class ReceiveSharingIntentHelper {
 
 
   public void clearFileNames(Intent intent){
+    if(intent == null) return;
     String type = intent.getType();
     if(type == null) return;
     if (type.startsWith("text")) {

--- a/android/src/main/java/com/reactnativereceivesharingintent/ReceiveSharingIntentModule.java
+++ b/android/src/main/java/com/reactnativereceivesharingintent/ReceiveSharingIntentModule.java
@@ -40,7 +40,6 @@ public class ReceiveSharingIntentModule extends ReactContextBaseJavaModule {
     if(mActivity == null) { return; }
     Intent intent = mActivity.getIntent();
     receiveSharingIntentHelper.sendFileNames(reactContext, intent, promise);
-    mActivity.setIntent(null);
   }
 
   @ReactMethod
@@ -48,7 +47,9 @@ public class ReceiveSharingIntentModule extends ReactContextBaseJavaModule {
     Activity mActivity = getCurrentActivity();
     if(mActivity == null) { return; }
     Intent intent = mActivity.getIntent();
-    receiveSharingIntentHelper.clearFileNames(intent);
+    if (intent != null) {
+      receiveSharingIntentHelper.clearFileNames(intent);
+    }
   }
 
 

--- a/src/ReceiveSharingIntent.interfaces.ts
+++ b/src/ReceiveSharingIntent.interfaces.ts
@@ -1,6 +1,7 @@
 
 export interface IReceiveSharingIntent{
     getReceivedFiles(handler: Function , errorHandler: Function, protocol: string ): void,
+    clearFileNames() :void,
 }
 
 export interface IUtils{

--- a/src/ReceiveSharingIntent.ts
+++ b/src/ReceiveSharingIntent.ts
@@ -36,6 +36,9 @@ class ReceiveSharingIntentModule implements IReceiveSharingIntent {
         this.isClear = true;
     }
 
+    clearFileNames() {
+        ReceiveSharingIntent.clearFileNames();
+    }
     
    protected getFileNames(handler: Function, errorHandler: Function, url: string){
         if(this.isIos){


### PR DESCRIPTION
Now there is a method to call in order to clean the list of files: clearFileNames()
In this way the list of shared file is kept until the clearFileNames() methods is called.